### PR TITLE
cannot import name 'Authing' from 'authing'

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ pip install authing
 ----------
 
 ``` python
-from authing import Authing
+from authing.authing import Authing
 
 clientId = 'your_client_id'
 secret = 'your_app_secret'


### PR DESCRIPTION
```ipython
In [1]: from authing import Authing                                                                                           
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-1-a1912f3b46ad> in <module>
----> 1 from authing import Authing

ImportError: cannot import name 'Authing' from 'authing' (/home/mymusise/pro/trade-server/env/lib/python3.7/site-packages/authing/__init__.py)
```

fixed.